### PR TITLE
Refresh blog UI with LP-style hero, gradient mesh, particles, and parallax

### DIFF
--- a/_data/strings.yml
+++ b/_data/strings.yml
@@ -7,6 +7,11 @@ ja:
     profile: "Profile"
     apps: "Apps"
     tags: "Tags"
+  hero:
+    eyebrow: "Tech Notes & Experiments"
+    title: "日々のメモ、コードと共に。"
+    subtitle: "フロントエンド、インフラ、ツール開発まで。気になったことを記録した技術ブログです。"
+    cta: "最新の投稿を読む"
   common:
     clear: "クリア"
     copy: "コピー"
@@ -436,6 +441,11 @@ en:
     profile: "Profile"
     apps: "Apps"
     tags: "Tags"
+  hero:
+    eyebrow: "Tech Notes & Experiments"
+    title: "Notes from the daily code grind."
+    subtitle: "Frontend, infrastructure, and tools — a personal log of things worth remembering."
+    cta: "Read the latest posts"
   common:
     clear: "Clear"
     copy: "Copy"

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -49,7 +49,15 @@
   </head>
 
   <body>
-    <div class="wrapper-masthead">
+    <div class="bg-fx" aria-hidden="true">
+      <div class="bg-fx__blob bg-fx__blob--a"></div>
+      <div class="bg-fx__blob bg-fx__blob--b"></div>
+      <div class="bg-fx__blob bg-fx__blob--c"></div>
+      <div class="bg-fx__grid"></div>
+      <canvas class="bg-fx__particles" id="bg-particles"></canvas>
+    </div>
+
+    <div class="wrapper-masthead" data-parallax="0.25">
       <div class="container">
         <header class="masthead clearfix">
           <a href="{{ site.baseurl }}/" class="site-avatar">
@@ -197,6 +205,162 @@
       window.i18n = function(key) {
         return window.autoLanguageDetector.getTranslation(key, window.autoLanguageDetector.getCurrentLanguage()) || key;
       };
+
+      (function initFrontFx() {
+        const reduceMotion = window.matchMedia('(prefers-reduced-motion: reduce)').matches;
+        // タッチデバイスやコア数の少ない環境では描画コストの高いパーティクルを省略
+        const isCoarsePointer = window.matchMedia('(hover: none) and (pointer: coarse)').matches;
+        const lowCores = (navigator.hardwareConcurrency || 4) < 4;
+        const enableParticles = !reduceMotion && !isCoarsePointer && !lowCores;
+
+        const canvas = document.getElementById('bg-particles');
+        if (enableParticles && canvas && canvas.getContext) {
+          const ctx = canvas.getContext('2d');
+          const dpr = Math.min(window.devicePixelRatio || 1, 2);
+          const LINK_DIST = 110;
+          const LINK_DIST_SQ = LINK_DIST * LINK_DIST;
+          let width = 0;
+          let height = 0;
+          let particles = [];
+          let pointer = null;
+          let visible = true;
+          let resizeTimer = 0;
+
+          function resize() {
+            width = window.innerWidth;
+            height = window.innerHeight;
+            canvas.width = width * dpr;
+            canvas.height = height * dpr;
+            canvas.style.width = width + 'px';
+            canvas.style.height = height + 'px';
+            ctx.setTransform(dpr, 0, 0, dpr, 0, 0);
+
+            const target = Math.min(60, Math.max(20, Math.floor((width * height) / 32000)));
+            particles = new Array(target).fill(0).map(() => ({
+              x: Math.random() * width,
+              y: Math.random() * height,
+              vx: (Math.random() - 0.5) * 0.3,
+              vy: (Math.random() - 0.5) * 0.3,
+              r: Math.random() * 1.6 + 0.6
+            }));
+          }
+
+          function step() {
+            if (!visible) {
+              requestAnimationFrame(step);
+              return;
+            }
+            ctx.clearRect(0, 0, width, height);
+            for (let i = 0; i < particles.length; i++) {
+              const p = particles[i];
+              p.x += p.vx;
+              p.y += p.vy;
+              if (p.x < -10) p.x = width + 10;
+              if (p.x > width + 10) p.x = -10;
+              if (p.y < -10) p.y = height + 10;
+              if (p.y > height + 10) p.y = -10;
+
+              if (pointer) {
+                const dxp = p.x - pointer.x;
+                const dyp = p.y - pointer.y;
+                const dp2 = dxp * dxp + dyp * dyp;
+                if (dp2 < LINK_DIST_SQ) {
+                  const f = (1 - dp2 / LINK_DIST_SQ) * 0.6;
+                  p.x += (dxp / Math.sqrt(dp2 || 1)) * f;
+                  p.y += (dyp / Math.sqrt(dp2 || 1)) * f;
+                }
+              }
+
+              ctx.beginPath();
+              ctx.fillStyle = 'rgba(102, 126, 234, 0.55)';
+              ctx.arc(p.x, p.y, p.r, 0, Math.PI * 2);
+              ctx.fill();
+            }
+
+            for (let i = 0; i < particles.length; i++) {
+              for (let j = i + 1; j < particles.length; j++) {
+                const a = particles[i];
+                const b = particles[j];
+                const dx = a.x - b.x;
+                const dy = a.y - b.y;
+                const d2 = dx * dx + dy * dy;
+                if (d2 < LINK_DIST_SQ) {
+                  const alpha = (1 - d2 / LINK_DIST_SQ) * 0.35;
+                  ctx.strokeStyle = 'rgba(118, 75, 162, ' + alpha.toFixed(3) + ')';
+                  ctx.lineWidth = 1;
+                  ctx.beginPath();
+                  ctx.moveTo(a.x, a.y);
+                  ctx.lineTo(b.x, b.y);
+                  ctx.stroke();
+                }
+              }
+            }
+            requestAnimationFrame(step);
+          }
+
+          window.addEventListener('resize', () => {
+            clearTimeout(resizeTimer);
+            resizeTimer = setTimeout(resize, 150);
+          });
+          window.addEventListener('pointermove', (e) => {
+            pointer = { x: e.clientX, y: e.clientY };
+          });
+          window.addEventListener('pointerleave', () => {
+            pointer = null;
+          });
+          if ('IntersectionObserver' in window) {
+            new IntersectionObserver(([entry]) => {
+              visible = entry.isIntersecting;
+            }).observe(canvas);
+          }
+          resize();
+          requestAnimationFrame(step);
+        }
+
+        if (reduceMotion) return;
+
+        const parallaxTargets = Array.from(document.querySelectorAll('[data-parallax]')).map((node) => ({
+          node,
+          factor: parseFloat(node.dataset.parallax) || 0
+        }));
+        const blobTargets = Array.from(document.querySelectorAll('.bg-fx__blob')).map((node, i) => ({
+          node,
+          factor: 0.05 + i * 0.04
+        }));
+        let scrollY = window.scrollY;
+        let ticking = false;
+
+        function applyParallax() {
+          for (const { node, factor } of parallaxTargets) {
+            node.style.transform = 'translate3d(0,' + (-scrollY * factor).toFixed(2) + 'px,0)';
+          }
+          for (const { node, factor } of blobTargets) {
+            node.style.transform = 'translate3d(0,' + (-scrollY * factor).toFixed(2) + 'px,0)';
+          }
+          ticking = false;
+        }
+
+        window.addEventListener('scroll', () => {
+          scrollY = window.scrollY;
+          if (!ticking) {
+            requestAnimationFrame(applyParallax);
+            ticking = true;
+          }
+        }, { passive: true });
+
+        if ('IntersectionObserver' in window) {
+          const io = new IntersectionObserver((entries) => {
+            entries.forEach((entry) => {
+              if (entry.isIntersecting) {
+                entry.target.classList.add('is-visible');
+                io.unobserve(entry.target);
+              }
+            });
+          }, { rootMargin: '0px 0px -10% 0px', threshold: 0.05 });
+
+          document.querySelectorAll('.reveal, .posts > .post').forEach((el) => io.observe(el));
+        }
+      })();
 
       // ページ読み込み時にツールページを検出
       window.addEventListener('DOMContentLoaded', function() {

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -208,7 +208,6 @@
 
       (function initFrontFx() {
         const reduceMotion = window.matchMedia('(prefers-reduced-motion: reduce)').matches;
-        // タッチデバイスやコア数の少ない環境では描画コストの高いパーティクルを省略
         const isCoarsePointer = window.matchMedia('(hover: none) and (pointer: coarse)').matches;
         const lowCores = (navigator.hardwareConcurrency || 4) < 4;
         const enableParticles = !reduceMotion && !isCoarsePointer && !lowCores;
@@ -217,13 +216,12 @@
         if (enableParticles && canvas && canvas.getContext) {
           const ctx = canvas.getContext('2d');
           const dpr = Math.min(window.devicePixelRatio || 1, 2);
-          const LINK_DIST = 110;
-          const LINK_DIST_SQ = LINK_DIST * LINK_DIST;
+          const LINK_DIST_SQ = 110 * 110;
           let width = 0;
           let height = 0;
           let particles = [];
           let pointer = null;
-          let visible = true;
+          let running = false;
           let resizeTimer = 0;
 
           function resize() {
@@ -246,10 +244,7 @@
           }
 
           function step() {
-            if (!visible) {
-              requestAnimationFrame(step);
-              return;
-            }
+            if (!running) return;
             ctx.clearRect(0, 0, width, height);
             for (let i = 0; i < particles.length; i++) {
               const p = particles[i];
@@ -310,34 +305,42 @@
           });
           if ('IntersectionObserver' in window) {
             new IntersectionObserver(([entry]) => {
-              visible = entry.isIntersecting;
+              if (entry.isIntersecting && !running) {
+                running = true;
+                requestAnimationFrame(step);
+              } else if (!entry.isIntersecting) {
+                running = false;
+              }
             }).observe(canvas);
           }
           resize();
+          running = true;
           requestAnimationFrame(step);
         }
 
         if (reduceMotion) return;
 
-        const parallaxTargets = Array.from(document.querySelectorAll('[data-parallax]')).map((node) => ({
-          node,
-          factor: parseFloat(node.dataset.parallax) || 0
-        }));
-        const blobTargets = Array.from(document.querySelectorAll('.bg-fx__blob')).map((node, i) => ({
-          node,
-          factor: 0.05 + i * 0.04
-        }));
+        const parallaxTargets = [
+          ...Array.from(document.querySelectorAll('[data-parallax]')).map((node) => ({
+            node,
+            factor: parseFloat(node.dataset.parallax) || 0
+          })),
+          ...Array.from(document.querySelectorAll('.bg-fx__blob')).map((node, i) => ({
+            node,
+            factor: 0.05 + i * 0.04
+          }))
+        ];
         let scrollY = window.scrollY;
+        let lastScrollY = -1;
         let ticking = false;
 
         function applyParallax() {
+          ticking = false;
+          if (scrollY === lastScrollY) return;
+          lastScrollY = scrollY;
           for (const { node, factor } of parallaxTargets) {
             node.style.transform = 'translate3d(0,' + (-scrollY * factor).toFixed(2) + 'px,0)';
           }
-          for (const { node, factor } of blobTargets) {
-            node.style.transform = 'translate3d(0,' + (-scrollY * factor).toFixed(2) + 'px,0)';
-          }
-          ticking = false;
         }
 
         window.addEventListener('scroll', () => {

--- a/_sass/_variables.scss
+++ b/_sass/_variables.scss
@@ -10,6 +10,11 @@ $Beko-Rebranding-Concept-4-hex: #88d4f2;
 $Beko-Rebranding-Concept-5-hex: #f27405;
 $blue: #146a8c;
 
+// LP-style accent palette (used for hero, gradient text, particle canvas)
+$brand-indigo: #6366f1;
+$brand-pink: #ec4899;
+$brand-cyan: #06b6d4;
+
 // Grays
 $black: #111;
 $darkerGray: #222;

--- a/index.html
+++ b/index.html
@@ -2,7 +2,19 @@
 layout: default
 ---
 
-<div class="posts">
+{% if paginator.page == 1 or paginator.page == nil %}
+<section class="hero reveal" data-parallax="0.12">
+  <span class="hero__eyebrow" data-i18n="hero.eyebrow">Tech Notes &amp; Experiments</span>
+  <h1 class="hero__title" data-i18n="hero.title">日々のメモ、コードと共に。</h1>
+  <p class="hero__subtitle" data-i18n="hero.subtitle">
+    フロントエンド、インフラ、ツール開発まで。気になったことを記録した技術ブログです。
+  </p>
+  <a href="#latest" class="hero__cta" data-i18n="hero.cta">最新の投稿を読む</a>
+  <div class="hero__scroll" aria-hidden="true"></div>
+</section>
+{% endif %}
+
+<div class="posts" id="latest">
   {% for post in paginator.posts %}
   <article class="post">
     <h1>

--- a/style.scss
+++ b/style.scss
@@ -36,12 +36,95 @@ nav a {
 }
 
 body {
-  background: linear-gradient(135deg, #f8fafc 0%, #e2e8f0 50%, #cbd5e0 100%);
+  background: #f6f8ff;
+  background-image:
+    radial-gradient(ellipse at top left, rgba(102, 126, 234, 0.18), transparent 55%),
+    radial-gradient(ellipse at top right, rgba(236, 72, 153, 0.14), transparent 55%),
+    radial-gradient(ellipse at bottom, rgba(56, 189, 248, 0.18), transparent 60%),
+    linear-gradient(180deg, #f8fafc 0%, #eef2ff 60%, #e0e7ff 100%);
+  background-attachment: fixed;
   min-height: 100vh;
   font: 18px/1.6;
   font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", "Roboto", "Helvetica Neue", Arial, sans-serif;
   color: #2d3748;
   overflow-x: hidden;
+}
+
+.bg-fx {
+  position: fixed;
+  inset: 0;
+  z-index: -1;
+  overflow: hidden;
+  pointer-events: none;
+}
+
+.bg-fx__blob {
+  position: absolute;
+  width: 60vmax;
+  height: 60vmax;
+  border-radius: 50%;
+  filter: blur(80px);
+  opacity: 0.55;
+  mix-blend-mode: screen;
+  will-change: transform;
+  animation: blobFloat 22s ease-in-out infinite alternate;
+}
+
+.bg-fx__blob--a {
+  top: -20vmax;
+  left: -15vmax;
+  background: radial-gradient(circle at 30% 30%, #a78bfa, #6366f1 60%, transparent 70%);
+}
+
+.bg-fx__blob--b {
+  top: 20vh;
+  right: -20vmax;
+  background: radial-gradient(circle at 60% 40%, #f472b6, #ec4899 55%, transparent 70%);
+  animation-duration: 28s;
+  animation-delay: -6s;
+}
+
+.bg-fx__blob--c {
+  bottom: -25vmax;
+  left: 10vw;
+  background: radial-gradient(circle at 50% 50%, #38bdf8, #0ea5e9 55%, transparent 70%);
+  animation-duration: 32s;
+  animation-delay: -12s;
+}
+
+.bg-fx__grid {
+  position: absolute;
+  inset: 0;
+  background-image:
+    linear-gradient(rgba(99, 102, 241, 0.06) 1px, transparent 1px),
+    linear-gradient(90deg, rgba(99, 102, 241, 0.06) 1px, transparent 1px);
+  background-size: 48px 48px;
+  mask-image: radial-gradient(ellipse at center, rgba(0, 0, 0, 0.6) 0%, transparent 75%);
+  -webkit-mask-image: radial-gradient(ellipse at center, rgba(0, 0, 0, 0.6) 0%, transparent 75%);
+}
+
+.bg-fx__particles {
+  position: absolute;
+  inset: 0;
+  width: 100%;
+  height: 100%;
+}
+
+@keyframes blobFloat {
+  0% { transform: translate3d(0, 0, 0) scale(1); }
+  50% { transform: translate3d(4vw, -3vh, 0) scale(1.08); }
+  100% { transform: translate3d(-3vw, 4vh, 0) scale(0.95); }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .bg-fx__blob { animation: none; }
+}
+
+// 高負荷な合成を避けるためモバイルでは1個のブロブとグリッドを抑える
+@include mobile {
+  .bg-fx__blob { filter: blur(50px); }
+  .bg-fx__blob--c { display: none; }
+  .bg-fx__grid { opacity: 0.5; }
 }
 
 .container {
@@ -264,13 +347,27 @@ th {
 
 .site-name {
   margin: 0;
-  color: #2d3748;
   cursor: pointer;
-  font-weight: 700;
+  font-weight: 800;
   font-size: 32px;
   letter-spacing: 1px;
   border-bottom: none;
   text-shadow: none;
+
+  a {
+    background: linear-gradient(120deg, #6366f1 0%, #ec4899 50%, #06b6d4 100%);
+    background-size: 200% 200%;
+    -webkit-background-clip: text;
+    background-clip: text;
+    -webkit-text-fill-color: transparent;
+    color: transparent;
+    animation: gradientShift 8s ease infinite;
+  }
+}
+
+@keyframes gradientShift {
+  0%, 100% { background-position: 0% 50%; }
+  50% { background-position: 100% 50%; }
 }
 
 .site-description {
@@ -736,33 +833,8 @@ iframe {
   box-shadow: 0 4px 15px rgba(0, 0, 0, 0.1);
 }
 
-// フェードインアニメーション（軽量化）
-@keyframes fadeInUp {
-  from {
-    opacity: 0;
-    transform: translate3d(0, 20px, 0);
-  }
-  to {
-    opacity: 1;
-    transform: translate3d(0, 0, 0);
-  }
-}
-
-.posts > .post {
-  animation: fadeInUp 0.4s ease-out both;
-}
-
-.posts > .post:nth-child(1) { animation-delay: 0.05s; }
-.posts > .post:nth-child(2) { animation-delay: 0.1s; }
-.posts > .post:nth-child(3) { animation-delay: 0.15s; }
-.posts > .post:nth-child(4) { animation-delay: 0.2s; }
-.posts > .post:nth-child(5) { animation-delay: 0.25s; }
-
-/* スクロール中はアニメーションを無効化 */
-@media (prefers-reduced-motion: reduce) {
-  .posts > .post {
-    animation: none;
-  }
+@for $i from 1 through 5 {
+  .posts > .post:nth-child(#{$i}) { transition-delay: #{$i * 0.05}s; }
 }
 
 // GitHubリポジトリカードのレスポンシブ対応
@@ -892,6 +964,168 @@ iframe {
         margin: 0 4px;
       }
     }
+  }
+}
+
+.hero {
+  position: relative;
+  text-align: center;
+  padding: 80px 20px 90px;
+  margin-bottom: 40px;
+  overflow: hidden;
+
+  @include mobile {
+    padding: 50px 16px 36px;
+    margin-bottom: 24px;
+  }
+}
+
+.hero__eyebrow {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  padding: 6px 14px;
+  font-size: 12px;
+  font-weight: 600;
+  letter-spacing: 1.5px;
+  text-transform: uppercase;
+  color: #6366f1;
+  background: rgba(255, 255, 255, 0.7);
+  border: 1px solid rgba(99, 102, 241, 0.25);
+  border-radius: 999px;
+  backdrop-filter: blur(10px);
+  box-shadow: 0 4px 16px rgba(99, 102, 241, 0.12);
+
+  &::before {
+    content: "";
+    width: 8px;
+    height: 8px;
+    border-radius: 50%;
+    background: #ec4899;
+    box-shadow: 0 0 0 4px rgba(236, 72, 153, 0.25);
+    animation: heroPulse 2s ease-in-out infinite;
+  }
+}
+
+@keyframes heroPulse {
+  0%, 100% { box-shadow: 0 0 0 4px rgba(236, 72, 153, 0.25); }
+  50% { box-shadow: 0 0 0 10px rgba(236, 72, 153, 0); }
+}
+
+.hero__title {
+  margin: 24px auto 18px;
+  max-width: 880px;
+  font-size: clamp(36px, 6vw, 64px);
+  font-weight: 800;
+  line-height: 1.15;
+  letter-spacing: -0.02em;
+  background: linear-gradient(120deg, #1e293b 0%, #6366f1 35%, #ec4899 65%, #0ea5e9 100%);
+  background-size: 200% 200%;
+  -webkit-background-clip: text;
+  background-clip: text;
+  -webkit-text-fill-color: transparent;
+  color: transparent;
+  animation: gradientShift 10s ease infinite;
+}
+
+.hero__subtitle {
+  max-width: 640px;
+  margin: 0 auto 32px;
+  font-size: clamp(15px, 1.6vw, 18px);
+  line-height: 1.7;
+  color: #475569;
+}
+
+.hero__cta {
+  display: inline-flex;
+  align-items: center;
+  gap: 10px;
+  padding: 14px 28px;
+  font-weight: 600;
+  font-size: 15px;
+  letter-spacing: 0.4px;
+  color: #fff;
+  background: linear-gradient(120deg, #6366f1 0%, #ec4899 100%);
+  background-size: 200% 200%;
+  border-radius: 999px;
+  box-shadow: 0 12px 30px rgba(99, 102, 241, 0.35);
+  transition: transform 0.25s ease, box-shadow 0.25s ease, background-position 0.6s ease;
+
+  &:hover {
+    color: #fff;
+    transform: translateY(-2px);
+    background-position: 100% 50%;
+    box-shadow: 0 18px 40px rgba(236, 72, 153, 0.45);
+  }
+
+  &::after {
+    content: "→";
+    transition: transform 0.25s ease;
+  }
+
+  &:hover::after {
+    transform: translateX(4px);
+  }
+}
+
+.hero__scroll {
+  position: absolute;
+  bottom: 24px;
+  left: 50%;
+  transform: translateX(-50%);
+  width: 22px;
+  height: 36px;
+  border-radius: 12px;
+  border: 2px solid rgba(99, 102, 241, 0.35);
+  opacity: 0.7;
+
+  &::before {
+    content: "";
+    position: absolute;
+    top: 6px;
+    left: 50%;
+    width: 3px;
+    height: 7px;
+    margin-left: -1.5px;
+    border-radius: 2px;
+    background: #6366f1;
+    animation: scrollDot 1.6s ease-in-out infinite;
+  }
+
+  @include mobile {
+    display: none;
+  }
+}
+
+@keyframes scrollDot {
+  0% { transform: translateY(0); opacity: 1; }
+  60% { transform: translateY(12px); opacity: 0; }
+  100% { transform: translateY(0); opacity: 0; }
+}
+
+.reveal,
+.posts > .post {
+  opacity: 0;
+  transform: translate3d(0, 28px, 0);
+  transition:
+    opacity 0.7s ease,
+    transform 0.7s cubic-bezier(0.22, 1, 0.36, 1),
+    box-shadow 0.3s ease,
+    background-color 0.3s ease;
+}
+
+.reveal.is-visible,
+.posts > .post.is-visible {
+  opacity: 1;
+  transform: translate3d(0, 0, 0);
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .reveal,
+  .posts > .post {
+    opacity: 1;
+    transform: none;
+    transition: none;
   }
 }
 

--- a/style.scss
+++ b/style.scss
@@ -73,13 +73,13 @@ body {
 .bg-fx__blob--a {
   top: -20vmax;
   left: -15vmax;
-  background: radial-gradient(circle at 30% 30%, #a78bfa, #6366f1 60%, transparent 70%);
+  background: radial-gradient(circle at 30% 30%, #a78bfa, #{$brand-indigo} 60%, transparent 70%);
 }
 
 .bg-fx__blob--b {
   top: 20vh;
   right: -20vmax;
-  background: radial-gradient(circle at 60% 40%, #f472b6, #ec4899 55%, transparent 70%);
+  background: radial-gradient(circle at 60% 40%, #f472b6, #{$brand-pink} 55%, transparent 70%);
   animation-duration: 28s;
   animation-delay: -6s;
 }
@@ -120,7 +120,7 @@ body {
   .bg-fx__blob { animation: none; }
 }
 
-// 高負荷な合成を避けるためモバイルでは1個のブロブとグリッドを抑える
+// blur + screen blend on a 60vmax element tanks mobile FPS — drop one blob and soften the grid.
 @include mobile {
   .bg-fx__blob { filter: blur(50px); }
   .bg-fx__blob--c { display: none; }
@@ -355,7 +355,7 @@ th {
   text-shadow: none;
 
   a {
-    background: linear-gradient(120deg, #6366f1 0%, #ec4899 50%, #06b6d4 100%);
+    background: linear-gradient(120deg, #{$brand-indigo} 0%, #{$brand-pink} 50%, #{$brand-cyan} 100%);
     background-size: 200% 200%;
     -webkit-background-clip: text;
     background-clip: text;
@@ -989,7 +989,7 @@ iframe {
   font-weight: 600;
   letter-spacing: 1.5px;
   text-transform: uppercase;
-  color: #6366f1;
+  color: #{$brand-indigo};
   background: rgba(255, 255, 255, 0.7);
   border: 1px solid rgba(99, 102, 241, 0.25);
   border-radius: 999px;
@@ -1001,7 +1001,7 @@ iframe {
     width: 8px;
     height: 8px;
     border-radius: 50%;
-    background: #ec4899;
+    background: #{$brand-pink};
     box-shadow: 0 0 0 4px rgba(236, 72, 153, 0.25);
     animation: heroPulse 2s ease-in-out infinite;
   }
@@ -1019,7 +1019,7 @@ iframe {
   font-weight: 800;
   line-height: 1.15;
   letter-spacing: -0.02em;
-  background: linear-gradient(120deg, #1e293b 0%, #6366f1 35%, #ec4899 65%, #0ea5e9 100%);
+  background: linear-gradient(120deg, #1e293b 0%, #{$brand-indigo} 35%, #{$brand-pink} 65%, #0ea5e9 100%);
   background-size: 200% 200%;
   -webkit-background-clip: text;
   background-clip: text;
@@ -1045,7 +1045,7 @@ iframe {
   font-size: 15px;
   letter-spacing: 0.4px;
   color: #fff;
-  background: linear-gradient(120deg, #6366f1 0%, #ec4899 100%);
+  background: linear-gradient(120deg, #{$brand-indigo} 0%, #{$brand-pink} 100%);
   background-size: 200% 200%;
   border-radius: 999px;
   box-shadow: 0 12px 30px rgba(99, 102, 241, 0.35);
@@ -1088,7 +1088,7 @@ iframe {
     height: 7px;
     margin-left: -1.5px;
     border-radius: 2px;
-    background: #6366f1;
+    background: #{$brand-indigo};
     animation: scrollDot 1.6s ease-in-out infinite;
   }
 


### PR DESCRIPTION
## Summary

最近のプロダクトLPっぽいフロント表現に寄せたブログUI刷新。

- **背景**: 動的なラジアルメッシュグラデ + 3つの巨大ブラー・ブロブ (`mix-blend-mode: screen`) + うっすらグリッド。モバイルではブロブを1個減らして blur を 50px に抑え、塗りコストを下げる。
- **パーティクル**: Canvas でドット同士を線でつなぐ典型のやつ。マウス追従の反発あり。`prefers-reduced-motion` / `coarse-pointer` / `hardwareConcurrency < 4` のときはスキップ。`IntersectionObserver` で画面外のときは rAF 内描画を停止。
- **パララックス**: マストヘッドとヒーローを `data-parallax` で軽く動かし、ブロブも係数違いで追従。`scroll` は rAF コアレッシング済み。
- **ヒーロー**: アイブロウチップ・グラデーションタイトル・サブコピー・CTA・スクロールキューを `index.html` の1ページ目限定で表示。i18n（`ja` / `en`）対応。
- **スクロールリビール**: 既存の常時実行 `fadeInUp` keyframe を `IntersectionObserver` ベースのリビールに置き換え。投稿カードの hover トランジション（`box-shadow` / `background-color`）が消えないよう transition プロパティを併記。

## Test plan

- [ ] `bundle exec jekyll serve` でトップ・記事ページ・タグページの表示確認
- [ ] パーティクルが動く（デスクトップ）／動かない（タッチ・低コア・reduced-motion）の確認
- [ ] ヒーロー CTA → `#latest` のスクロール、ヒーロー1ページ目のみ表示
- [ ] スクロールでマストヘッド／ブロブが少しずつズレる
- [ ] 投稿カードに hover したとき box-shadow が滑らかに変わる（transition 上書きで壊れていない）
- [ ] モバイルで `bg-fx__blob--c` が非表示・blur が軽量化されている

https://claude.ai/code/session_01BEVdtifewFjsbG5tNQTbZJ

---
_Generated by [Claude Code](https://claude.ai/code/session_01BEVdtifewFjsbG5tNQTbZJ)_