### PR TITLE
定例会議: Google Analytics(GA4)を追加

### DIFF
--- a/apps/teirei-kaigi/index.html
+++ b/apps/teirei-kaigi/index.html
@@ -32,6 +32,15 @@
     <meta name="twitter:image" content="https://blog.taross-f.dev/apps/teirei-kaigi/ogp.png" />
     <meta name="twitter:image:alt" content="定例会議のビデオ会議画面。参加者のうち1人が見知らぬ「user_039」になっている。" />
 
+    <!-- Google tag (gtag.js) -->
+    <script async src="https://www.googletagmanager.com/gtag/js?id=G-HHQ0669BP8"></script>
+    <script>
+      window.dataLayer = window.dataLayer || [];
+      function gtag(){dataLayer.push(arguments);}
+      gtag('js', new Date());
+      gtag('config', 'G-HHQ0669BP8');
+    </script>
+
     <style>html,body{margin:0;padding:0;background:#141619}</style>
     <script type="module" crossorigin src="/apps/teirei-kaigi/assets/index-Caw48taR.js"></script>
   </head>

--- a/teirei-kaigi/index.html
+++ b/teirei-kaigi/index.html
@@ -32,6 +32,15 @@
     <meta name="twitter:image" content="https://blog.taross-f.dev/apps/teirei-kaigi/ogp.png" />
     <meta name="twitter:image:alt" content="定例会議のビデオ会議画面。参加者のうち1人が見知らぬ「user_039」になっている。" />
 
+    <!-- Google tag (gtag.js) -->
+    <script async src="https://www.googletagmanager.com/gtag/js?id=G-HHQ0669BP8"></script>
+    <script>
+      window.dataLayer = window.dataLayer || [];
+      function gtag(){dataLayer.push(arguments);}
+      gtag('js', new Date());
+      gtag('config', 'G-HHQ0669BP8');
+    </script>
+
     <style>html,body{margin:0;padding:0;background:#141619}</style>
   </head>
   <body>


### PR DESCRIPTION
## 概要

`apps/teirei-kaigi`（定例会議ゲーム）ページに Google Analytics（GA4）を追加しました。

このページは Vite + React の独立したSPAで Jekyll レイアウト（`_includes/analytics.html`）を通らないため、これまでブログ本体のGAでは計測されていませんでした。本PRで gtag スニペットを直接埋め込み、計測対象にします。

## 変更内容

- ブログ本体と**同じ計測プロパティ `G-HHQ0669BP8`** を使用し、計測を統合
- `apps/teirei-kaigi/index.html`（デプロイ先）と `teirei-kaigi/index.html`（ソース）の両方の `<head>` に gtag スニペットを追加

```html
<!-- Google tag (gtag.js) -->
<script async src="https://www.googletagmanager.com/gtag/js?id=G-HHQ0669BP8"></script>
<script>
  window.dataLayer = window.dataLayer || [];
  function gtag(){dataLayer.push(arguments);}
  gtag('js', new Date());
  gtag('config', 'G-HHQ0669BP8');
</script>
```

## 確認

マージ後、GitHub Pages 再ビルド → `https://blog.taross-f.dev/apps/teirei-kaigi/` にアクセスし、GA4 のリアルタイムレポートでヒットが確認できます。

https://claude.ai/code/session_01G2ARNGj629XANoBkRhBbnT

---
_Generated by [Claude Code](https://claude.ai/code/session_01G2ARNGj629XANoBkRhBbnT)_