### PR TITLE
定例会議: エンドレスモードのチート対策つきオンラインランキング

### DIFF
--- a/teirei-kaigi/CLAUDE.md
+++ b/teirei-kaigi/CLAUDE.md
@@ -11,6 +11,13 @@
 - **正解時に異変名は伏せる**(8番出口同様、答えは教えない)。何の異変だったかは図鑑でのみ開示する。
 - **エンドレスモード(`mode === "endless"`)**: 金曜まで完走(クリア)した人だけタイトルから解放される。クリア概念なしで会議が続き、連続正解数(`streak`)を競う。1度でも判定を誤るとゲームオーバー。自己ベストは `localStorage`(`tk_endless_best`、`loadEndlessBest`/`saveEndlessBest`)に永続化し、終了画面(`phase === "endlessover"`)で表示する。曜日ラベルは `DAYS[dayIdx % DAYS.length]` で循環表示し、ヘッダに `∞ streak` を出す。`succeed`/`fail` が `stateRef.current.mode` で分岐する(通常: 金曜クリア/月曜リスタート、エンドレス: streak加算/終了)。図鑑への記録はエンドレスでも行う。
 
+- **エンドレスは決定論出題**: 通常モードは `Math.random()` で出題するが、エンドレスは **seed由来の決定論列**で出題する(`src/endlessCore.js` の `generateSequence(seed, n)` を `startEndless` で先読みして `seqRef` に保持、`startMeeting` は `seqRef.current[day]` を参照)。これはサーバ側のスコア検証を可能にするための設計。出題プールはランごとに空から始まる自己完結式で、`localStorage` の `tk_used_anomalies`(通常モードのローテーション)には依存しない。図鑑記録(`tk_discovered_anomalies`)はエンドレスでも従来どおり行う。`startMeeting` は `seqRef.current` の有無で通常/エンドレスを判別する(`mode` stateのタイミングに依存しないため確実)。`joinFromTitle` は `seqRef`/`runRef` を null クリアして通常モードに戻す。
+
+- **オンラインランキング(チート対策つき)**: エンドレスの `streak` を Cloudflare Worker + D1 でランキング化する。**スコア値は送らず、各ラウンドの操作ログ(`{action: "leave"|"stay", elapsedMs}`)を送り、サーバが seed 列に突き合わせて streak を再計算する**ことでチートを防ぐ。実装は `worker/`(`README.md` にデプロイ手順)。決定論コア `src/endlessCore.js`(`generateSequence`/`replay`/`minPlayMs`/`ANOMALY_IDS`)を**クライアントとWorkerで共有**する。`ANOMALY_IDS` は `ANOMALIES.map(a => a.id)` の正本で、起動時(DEV)に一致を検証する — **異変を追加したら `endlessCore.js` の `ANOMALY_IDS` 末尾にも追記し、Workerを再デプロイすること**(順序を変えると乱数列が変わり既存記録と互換が壊れる)。
+  - **クライアント**: `startEndless` で `GET /session`(署名付き seed)を取得 → `runRef = {seed, sid, iat, sig, inputs[], roundStartMs}`。各ラウンドの判定時に `recordEndlessInput()` で操作ログを追記。ゲームオーバー時に `submitScore()` が `POST /submit`。終了画面で名前入力(`tk_player_name`)・自分の順位・上位10件を表示。`submitState`(idle/submitting/done/error/offline/invalid)でUIを出し分ける。`streak === 0` は登録対象外。
+  - **APIエンドポイント**は `import.meta.env.VITE_RANKING_API` で注入(`RANKING_API` 定数)。**未設定なら自動でオフライン**(ローカル乱数seedで遊べるが順位は送らない)。本番反映には Worker デプロイ後の URL で `VITE_RANKING_API=... npm run build` し直し、`apps/teirei-kaigi/` を差し替える必要がある。
+  - **サーバ検証**(`worker/index.js`): ① HMAC署名で seed 改ざんを検出(鍵は Worker のシークレット `HMAC_SECRET` のみ)② `sid` の UNIQUE 制約で二重送信を遮断 ③ `replay()` で操作ログを再生し streak を再計算(途中失敗・末尾以外の不正解・型/範囲を弾く)④ 信頼できる経過時間(発行 `iat` 〜 送信 `now`)と操作ログの所要時間を突き合わせ、瞬間周回(`too_fast`)を拒否。`stay`(完走)は実時間約35秒必須。**限界**: クライアント描画ゲームの性質上、画面データを読む自作ボットは完全には防げない。本実装が潰すのはスコア捏造POSTと瞬間周回(=現実的なチートの大半)。
+
 ## アーキテクチャ
 
 - `src/TeireiKaigi.jsx` に全実装(単一コンポーネント、依存はReactのみ)。
@@ -42,6 +49,7 @@
 - `view_anomalies` — 異変図鑑を開いた
 - `endless_start` — エンドレスモード開始(タイトル/終了画面の「もう一度」)
 - `endless_end` — エンドレス終了(`streak`=連続正解数, `best`=自己ベスト)
+- `ranking_submit` — ランキング送信結果(`result`=ok/error/invalid, ok時 `streak`/`rank`)
 - `back_to_title` — タイトルへ戻る(`from`=clear/anomalies/endless)
 - `affiliate_click` — タイトル下部 Special Thanks の着想元リンク(8番出口/8番乗り場)タップ(`product`=exit8/platform8)
 

--- a/teirei-kaigi/src/TeireiKaigi.jsx
+++ b/teirei-kaigi/src/TeireiKaigi.jsx
@@ -4,6 +4,14 @@ import {
   playClick, playLeave, playCaption, playSilence,
   playStart, playSuccess, playFail, playClear, playTick,
 } from "./sound";
+import { generateSequence, ANOMALY_IDS } from "./endlessCore";
+
+// エンドレスランキングのAPIエンドポイント(Cloudflare Worker)。
+// ビルド時に VITE_RANKING_API で指定する。未設定ならランキングは無効化され、
+// ゲームは従来どおり自己ベストのみで動作する(後方互換)。
+const RANKING_API = (import.meta.env && import.meta.env.VITE_RANKING_API) || "";
+// 先読み生成するエンドレスの最大ラウンド数(人間が到達しない十分大きな値)。
+const ENDLESS_MAX_ROUNDS = 600;
 
 // ============================================================
 // 定例会議 — 8番出口ライク・ビデオ会議異変探し プロトタイプ v2
@@ -29,6 +37,8 @@ const DISCOVERED_STORAGE_KEY = "tk_discovered_anomalies";
 const CLEARED_STORAGE_KEY = "tk_cleared";
 // エンドレスモードの最高連続正解数(永続)。クリア済みの人だけが遊べる。
 const ENDLESS_BEST_KEY = "tk_endless_best";
+// ランキング登録名(永続)。
+const PLAYER_NAME_KEY = "tk_player_name";
 
 const BASE_PARTICIPANTS = [
   { id: "tanaka", name: "田中", skin: "#e8b794", shirt: "#3a5a8c", bgType: "plain", bgA: "#2e3440", bgB: "#3b4252", muted: false, host: true },
@@ -213,6 +223,20 @@ const ANOMALIES = [
   },
 ];
 
+// 決定論コア(endlessCore)が持つ異変ID正本と、実際のANOMALIES定義の一致を起動時に検証する。
+// ズレるとサーバ側のスコア再生検証と食い違うため、開発中に必ず気づけるようにする。
+if (import.meta.env && import.meta.env.DEV) {
+  const ids = ANOMALIES.map((a) => a.id);
+  const same = ids.length === ANOMALY_IDS.length && ids.every((id, i) => id === ANOMALY_IDS[i]);
+  if (!same) {
+    console.error(
+      "[teirei-kaigi] ANOMALIES と endlessCore.ANOMALY_IDS が不一致です。" +
+        "endlessCore.js の ANOMALY_IDS を更新し、Workerも再デプロイしてください。",
+      { anomalies: ids, core: ANOMALY_IDS }
+    );
+  }
+}
+
 // localStorage上の異変IDリストを読み書きする共通ヘルパ。
 // 読み込み時に定義から消えたID・配列以外の不正値を除外する。
 function loadAnomalyIdList(key) {
@@ -272,6 +296,22 @@ function loadEndlessBest() {
 function saveEndlessBest(n) {
   try {
     localStorage.setItem(ENDLESS_BEST_KEY, String(n));
+  } catch {
+    /* 黙って無視 */
+  }
+}
+
+// ランキング登録名の読み書き。
+function loadPlayerName() {
+  try {
+    return (localStorage.getItem(PLAYER_NAME_KEY) || "").slice(0, 12);
+  } catch {
+    return "";
+  }
+}
+function savePlayerName(name) {
+  try {
+    localStorage.setItem(PLAYER_NAME_KEY, name);
   } catch {
     /* 黙って無視 */
   }
@@ -503,6 +543,14 @@ export default function TeireiKaigi() {
   const stateRef = useRef({});
   stateRef.current = { anomalyId, dayIdx, usedAnomalies, mode, streak };
 
+  // エンドレスの決定論実行用。seqRef が非nullの間はエンドレス進行中(=seed列で出題)。
+  const seqRef = useRef(null);   // generateSequence の結果(先読み列)
+  const runRef = useRef(null);   // { seed, sid, iat, sig, inputs[], roundStartMs } / オフライン時はsessionなし
+  // ランキングUI
+  const [playerName, setPlayerName] = useState(loadPlayerName);
+  const [ranking, setRanking] = useState(null);            // { streak, rank, top[] }
+  const [submitState, setSubmitState] = useState("idle");  // idle|submitting|done|error|offline|invalid
+
   const totalAnomalies = ANOMALIES.length;
   // discovered は loadAnomalyIdList で検証・重複排除済みなので件数はそのまま長さでよい。
   const discoveredSet = new Set(discovered); // 図鑑リストの一覧表示で使う
@@ -511,8 +559,12 @@ export default function TeireiKaigi() {
 
   const startMeeting = useCallback((day) => {
     let nextAnomaly = null;
-    if (Math.random() < ANOMALY_RATE) {
-      // 見破り済みリストは最新の永続値から読む(失敗で月曜に戻っても引き継ぐ)
+    const seq = seqRef.current;
+    if (seq) {
+      // エンドレス: seed由来の先読み列から決定論的に出題する(localStorageのプールには依存しない)。
+      nextAnomaly = seq[day] ? seq[day].anomalyId : null;
+    } else if (Math.random() < ANOMALY_RATE) {
+      // 通常モード: 見破り済みリストは最新の永続値から読む(失敗で月曜に戻っても引き継ぐ)
       // 出現時点では記録せず、全種類見破り済みだった場合のリセットのみ反映する
       const picked = pickAnomaly(loadUsedAnomalies());
       nextAnomaly = picked.anomalyId;
@@ -525,23 +577,58 @@ export default function TeireiKaigi() {
     setTimeLeft(MEETING_SECONDS);
     setCaptionIdx(0);
     setPhase("meeting");
+    // 操作ログ用にラウンド開始時刻を記録(オンラインのエンドレス時のみ使う)。
+    if (runRef.current) runRef.current.roundStartMs = Date.now();
     playStart();
   }, []);
 
   // タイトル/クリア画面からの参加: ユーザー操作中にAudioContextを起こす。
   const joinFromTitle = useCallback(() => {
     ensureAudio();
+    seqRef.current = null;   // 通常モードは決定論列を使わない(Math.random出題に戻す)
+    runRef.current = null;
     setMode("campaign");
     track("game_start");
     startMeeting(0);
   }, [startMeeting]);
 
   // エンドレスモード開始(クリア済みのみ解放)。クリア概念なしで連続正解数を競う。
-  const startEndless = useCallback(() => {
+  // サーバから署名付き seed を受け取り、その seed の決定論列で出題する。操作ログを記録して
+  // ゲームオーバー時にサーバへ送信し、再生検証を経てランキングに登録する。
+  // サーバが無い/到達不能なら、ローカル乱数seedで遊べるが順位送信はしない(後方互換)。
+  const startEndless = useCallback(async () => {
     ensureAudio();
     setMode("endless");
     setStreak(0);
+    setRanking(null);
+    setSubmitState("idle");
     track("endless_start");
+
+    let session = null;
+    if (RANKING_API) {
+      try {
+        const res = await fetch(`${RANKING_API}/session`, { method: "GET" });
+        if (res.ok) session = await res.json();
+      } catch {
+        /* オフライン: ローカルseedにフォールバック */
+      }
+    }
+    if (session && Number.isFinite(session.seed)) {
+      runRef.current = {
+        seed: session.seed >>> 0,
+        sid: session.sid,
+        iat: session.iat,
+        sig: session.sig,
+        inputs: [],
+        roundStartMs: 0,
+      };
+      seqRef.current = generateSequence(session.seed >>> 0, ENDLESS_MAX_ROUNDS);
+    } else {
+      // オフライン: 送信はしないが、決定論列でゲームは成立させる。
+      const localSeed = (Math.random() * 0xffffffff) >>> 0;
+      runRef.current = null;
+      seqRef.current = generateSequence(localSeed, ENDLESS_MAX_ROUNDS);
+    }
     startMeeting(0);
   }, [startMeeting]);
 
@@ -560,6 +647,55 @@ export default function TeireiKaigi() {
     track("meeting_result", { result, day_index: d + 1, anomaly_id: aId || "none", ...meta });
   }
 
+  // エンドレスの操作ログに1ラウンド分を追記する(オンライン実行時のみ)。
+  // action: "leave"(退出した) | "stay"(最後まで残った)。elapsedMsはラウンド開始からの経過。
+  function recordEndlessInput(action) {
+    const run = runRef.current;
+    if (!run) return;
+    const elapsedMs = Date.now() - (run.roundStartMs || Date.now());
+    run.inputs.push({ action, elapsedMs });
+  }
+
+  // ゲームオーバー時に操作ログをサーバへ送信し、再生検証を経てランキング登録する。
+  async function submitScore() {
+    const run = runRef.current;
+    if (!RANKING_API || !run) {
+      setSubmitState("offline");
+      return;
+    }
+    setSubmitState("submitting");
+    const nm = (playerName || "").trim().slice(0, 12);
+    savePlayerName(nm);
+    try {
+      const res = await fetch(`${RANKING_API}/submit`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          seed: run.seed,
+          sid: run.sid,
+          iat: run.iat,
+          sig: run.sig,
+          name: nm,
+          inputs: run.inputs,
+        }),
+      });
+      const data = await res.json().catch(() => ({}));
+      if (res.ok && data.ok) {
+        setRanking({ streak: data.streak, rank: data.rank, top: data.top || [] });
+        setSubmitState("done");
+        track("ranking_submit", { result: "ok", streak: data.streak, rank: data.rank });
+      } else {
+        // 検証で弾かれた(改ざん・時間不整合など)場合も含めて失敗扱い。
+        const invalid = data && data.error === "invalid_play";
+        setSubmitState(invalid ? "invalid" : "error");
+        track("ranking_submit", { result: invalid ? "invalid" : "error" });
+      }
+    } catch {
+      setSubmitState("error");
+      track("ranking_submit", { result: "error" });
+    }
+  }
+
   function fail(kind) {
     clearInterval(timerRef.current);
     playFail();
@@ -567,6 +703,9 @@ export default function TeireiKaigi() {
     trackMeetingResult("fail", { reason: kind });
     const { mode: m, streak: s } = stateRef.current;
     if (m === "endless") {
+      // 失敗したラウンドも操作ログに含める(末尾=不正解 が正規のゲームオーバー)。
+      // wrong=異変なしで退出した("leave") / stayed=異変ありに残った("stay")。
+      recordEndlessInput(kind === "wrong" ? "leave" : "stay");
       // エンドレス終了: 連続正解数を確定し、自己ベストを更新する。
       // endlessBest は state とlocalStorageが常に同期しているので state を使う。
       const isNewBest = s > endlessBest;
@@ -579,6 +718,16 @@ export default function TeireiKaigi() {
         isNewBest,
       });
       setPhase("endlessover");
+      // streak 0 は登録対象外。サーバ無しはオフライン。登録名があれば自動送信、無ければ入力を促す。
+      if (!runRef.current) {
+        setSubmitState("offline");
+      } else if (s <= 0) {
+        setSubmitState("idle");
+      } else if ((playerName || "").trim()) {
+        submitScore();
+      } else {
+        setSubmitState("idle");
+      }
       return;
     }
     // 通常モード: 見破り済みは永続化したまま月曜へ(見逃した異変は再挑戦できる)
@@ -612,6 +761,8 @@ export default function TeireiKaigi() {
     trackMeetingResult("success", { method: byLeaving ? "leave" : "stay" });
     // エンドレスモード: クリア概念なし。連続正解を伸ばし続ける(失敗で終了)。
     if (m === "endless") {
+      // 正解したラウンドを操作ログに追記(byLeaving=退出して正解 / それ以外=残って正解)。
+      recordEndlessInput(byLeaving ? "leave" : "stay");
       const nextStreak = s + 1;
       setStreak(nextStreak);
       playSuccess();
@@ -899,6 +1050,54 @@ export default function TeireiKaigi() {
           ) : (
             <div style={{ marginTop: 8, fontSize: 13, color: "#8a8f99", fontVariantNumeric: "tabular-nums" }}>最高記録 {endlessBest}</div>
           )}
+
+          {transition.streak > 0 && (
+            <div style={{ marginTop: 26, width: "100%", maxWidth: 360 }}>
+              {submitState === "offline" && (
+                <div style={{ fontSize: 12, color: "#6b7079" }}>ランキングはオフラインです</div>
+              )}
+              {submitState === "idle" && (
+                <div style={{ display: "flex", gap: 8, justifyContent: "center" }}>
+                  <input
+                    value={playerName}
+                    onChange={(e) => setPlayerName(e.target.value.slice(0, 12))}
+                    placeholder="なまえ(12字まで)"
+                    maxLength={12}
+                    style={{ flex: 1, minWidth: 0, padding: "10px 12px", borderRadius: 6, border: "1px solid #2c2f36", background: "#141518", color: "#e6e6e8", fontSize: 14 }}
+                  />
+                  <button className="tk-btn" onClick={() => { playClick(); submitScore(); }}
+                    style={{ background: "#caa66a", color: "#1a1a1a", padding: "10px 18px", whiteSpace: "nowrap", fontWeight: 700 }}>登録</button>
+                </div>
+              )}
+              {submitState === "submitting" && (
+                <div style={{ fontSize: 12, color: "#8a8f99" }}>送信中…</div>
+              )}
+              {(submitState === "error" || submitState === "invalid") && (
+                <div style={{ fontSize: 12, color: "#ff8a8a" }}>
+                  {submitState === "invalid" ? "スコアを検証できませんでした" : "送信に失敗しました"}
+                  <button className="tk-btn" onClick={() => { playClick(); submitScore(); }}
+                    style={{ marginLeft: 8, background: "#23262c", color: "#e6e6e8", padding: "4px 12px", fontSize: 12 }}>再試行</button>
+                </div>
+              )}
+              {submitState === "done" && ranking && (
+                <div>
+                  <div style={{ fontSize: 13, color: "#caa66a", marginBottom: 10 }}>
+                    あなたの順位 <strong style={{ fontSize: 18 }}>{ranking.rank}</strong> 位
+                  </div>
+                  <ol style={{ listStyle: "none", padding: 0, margin: 0, textAlign: "left" }}>
+                    {ranking.top.slice(0, 10).map((r, i) => (
+                      <li key={i} style={{ display: "flex", gap: 8, padding: "5px 10px", fontSize: 13, color: "#cdd0d6", background: i % 2 ? "transparent" : "#141518", borderRadius: 4 }}>
+                        <span style={{ color: "#8a8f99", width: 24, fontVariantNumeric: "tabular-nums" }}>{i + 1}</span>
+                        <span style={{ flex: 1, overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap" }}>{r.name}</span>
+                        <span style={{ color: "#ffd35a", fontVariantNumeric: "tabular-nums" }}>{r.streak}</span>
+                      </li>
+                    ))}
+                  </ol>
+                </div>
+              )}
+            </div>
+          )}
+
           <div style={{ display: "flex", gap: 12, marginTop: 36, flexWrap: "wrap", justifyContent: "center" }}>
             <button className="tk-btn" onClick={startEndless}
               style={{ background: "#3a6df0", color: "#fff", padding: "12px 32px" }}>もう一度</button>

--- a/teirei-kaigi/src/endlessCore.js
+++ b/teirei-kaigi/src/endlessCore.js
@@ -1,0 +1,130 @@
+// ============================================================
+// endlessCore.js — エンドレスモードの決定論コア
+// クライアント(TeireiKaigi.jsx)とサーバ(worker/index.js)で共有する。
+// ここを変えるとスコア検証の互換性が壊れるため、変更時は両者を必ず同時にデプロイすること。
+// React等への依存を持たない純粋なESMに保つ(Workerでもそのまま動かすため)。
+// ============================================================
+
+export const ANOMALY_RATE = 0.66;
+export const MEETING_SECONDS = 35;
+
+// 時間整合チェックの下限(ミリ秒)。
+// stay(完走)は35秒のタイマーを最後まで待つので実時間が必須。leave も最低操作時間を課す。
+export const MIN_LEAVE_MS = 700;
+export const MIN_STAY_MS = 32000;
+// 1ラウンドあたりの上限(分単位のゴミ値を弾く。タブのスロットリングを考慮し緩め)。
+export const MAX_ROUND_MS = 30 * 60 * 1000;
+// セッションの最大有効時間。これを超えた送信は古すぎるとして拒否する。
+export const MAX_SESSION_MS = 6 * 60 * 60 * 1000;
+// 1回の送信で受け付ける最大ラウンド数(異常な巨大配列を弾く)。
+export const MAX_ROUNDS = 1000;
+
+// 異変IDの正本。並び順が乱数列に影響するため並び替え・削除は禁止(末尾追加のみ可)。
+// TeireiKaigi.jsx の ANOMALIES.map(a => a.id) と完全一致していること(クライアント起動時に検証)。
+export const ANOMALY_IDS = [
+  "caption", "title", "speaker", "samename", "reversed", "button", "name",
+  "selfname", "clock", "count", "extra", "flip", "blink", "mute", "shadow",
+  "rec", "face", "eyecolor", "noblink", "selftalk", "joiner", "silence",
+  "timerup", "approach", "grow", "redden", "thirdeye",
+];
+
+// 決定論PRNG(mulberry32)。符号なし32bit seed から [0,1) を返す関数を生成する。
+export function mulberry32(seed) {
+  let a = seed >>> 0;
+  return function () {
+    a |= 0;
+    a = (a + 0x6d2b79f5) | 0;
+    let t = Math.imul(a ^ (a >>> 15), 1 | a);
+    t = (t + Math.imul(t ^ (t >>> 7), 61 | t)) ^ t;
+    return ((t ^ (t >>> 14)) >>> 0) / 4294967296;
+  };
+}
+
+// seed から最大 n ラウンド分の「出現する異変」列を先読み生成する。
+// クライアントは sequence[i] を見て描画し、サーバは同じ seed で同じ列を再生成して照合する。
+// プール消費は「正解(=見破った異変)は同一ランで再出現しない」を仮定する。エンドレスは
+// 正解でのみ継続するため、ゲームオーバー前の各ラウンドは必ず正解であり、この仮定が成り立つ。
+// 異変ありラウンド = 退出して正解 → そのIDをプールから除外。
+// 異変なしラウンド = 残って正解 → プールは不変。
+export function generateSequence(seed, n) {
+  const rng = mulberry32(seed);
+  const out = [];
+  let used = [];
+  for (let i = 0; i < n; i++) {
+    const hasAnomaly = rng() < ANOMALY_RATE;
+    let anomalyId = null;
+    if (hasAnomaly) {
+      let pool = ANOMALY_IDS.filter((id) => !used.includes(id));
+      if (pool.length === 0) {
+        pool = ANOMALY_IDS.slice();
+        used = [];
+      }
+      anomalyId = pool[Math.floor(rng() * pool.length)];
+      used = used.concat(anomalyId);
+    }
+    out.push({ hasAnomaly, anomalyId });
+  }
+  return out;
+}
+
+// 操作ログを seed 由来の列に突き合わせ、正式な streak を計算する(サーバ権威の判定)。
+// inputs: [{ action: "leave" | "stay", elapsedMs: number }] を各ラウンド1件、時系列順に。
+// 返り値: { ok, streak, reason }。ok=false の送信はランキングに採用しない。
+//
+// 検証内容:
+//  1. action と elapsedMs の型・範囲
+//  2. 各ラウンドの時間整合(stay は実時間35秒必須、leave も最低時間)
+//  3. seed 列との正誤判定で streak を再計算
+//  4. ゲームオーバー(不正解)は最後の1件のみ。途中で不正解なのに続いていたら不整合
+//  5. 末尾が不正解で終わっている(正規のゲームオーバー)こと
+export function replay(seed, inputs) {
+  if (!Array.isArray(inputs) || inputs.length === 0) {
+    return { ok: false, streak: 0, reason: "empty" };
+  }
+  if (inputs.length > MAX_ROUNDS) {
+    return { ok: false, streak: 0, reason: "too_long" };
+  }
+  const seq = generateSequence(seed, inputs.length);
+  let streak = 0;
+  for (let i = 0; i < inputs.length; i++) {
+    const inp = inputs[i];
+    if (!inp || (inp.action !== "leave" && inp.action !== "stay")) {
+      return { ok: false, streak, reason: "bad_action" };
+    }
+    const e = Number(inp.elapsedMs);
+    if (!Number.isFinite(e) || e < 0 || e > MAX_ROUND_MS) {
+      return { ok: false, streak, reason: "bad_time" };
+    }
+    if (inp.action === "stay" && e < MIN_STAY_MS) {
+      return { ok: false, streak, reason: "too_fast_stay" };
+    }
+    if (inp.action === "leave" && e < MIN_LEAVE_MS) {
+      return { ok: false, streak, reason: "too_fast_leave" };
+    }
+    const has = seq[i].hasAnomaly;
+    const correct =
+      (inp.action === "leave" && has) || (inp.action === "stay" && !has);
+    if (correct) {
+      streak++;
+      continue;
+    }
+    // 不正解 = ゲームオーバー。これより後に入力があれば「失敗後も継続」で不整合。
+    if (i !== inputs.length - 1) {
+      return { ok: false, streak, reason: "continued_after_fail" };
+    }
+    return { ok: true, streak, reason: "ok" };
+  }
+  // 全ラウンド正解で終わっている = ゲームオーバーになっていない(正規の送信ではない)。
+  return { ok: false, streak, reason: "no_gameover" };
+}
+
+// inputs から「最低限かかったはずの実プレイ時間(ms)」を求める。
+// サーバが信頼できる時刻(セッション発行〜送信)と突き合わせ、捏造した elapsedMs が
+// 実際の経過時間に収まっているかを検証するために使う。
+export function minPlayMs(inputs) {
+  let total = 0;
+  for (const inp of inputs) {
+    total += inp && inp.action === "stay" ? MIN_STAY_MS : MIN_LEAVE_MS;
+  }
+  return total;
+}

--- a/teirei-kaigi/worker/README.md
+++ b/teirei-kaigi/worker/README.md
@@ -1,0 +1,59 @@
+# 定例会議 エンドレスランキング Worker
+
+エンドレスモードの連続正解数(streak)をオンラインランキング化する Cloudflare Worker。
+**スコア値は受け取らず、操作ログをサーバ側で再生・検証して再計算する**ことでチートを防ぐ。
+
+## 仕組み(チート対策)
+
+1. `GET /session` で seed と署名付きセッション(`sid`/`iat`/`sig`)を発行。ゲームの判定乱数は
+   この seed の決定論PRNG(`src/endlessCore.js`)から先読み生成され、クライアントとサーバで一致する。
+2. クライアントは **スコアではなく操作ログ**(各ラウンドの `leave`/`stay` と所要時間)を送る。
+3. `POST /submit` で Worker が:
+   - HMAC 署名を検証(seed 改ざん検出。鍵は Worker 内のみ)
+   - `sid` の UNIQUE 制約で二重送信を遮断
+   - seed 列に操作ログを突き合わせて streak を再計算(`replay`)
+   - 信頼できるサーバ時刻(発行〜送信)と所要時間を突き合わせ、瞬間周回を拒否
+   - 検証を通った streak だけを D1 に記録
+4. `GET /top` で上位100件を返す。
+
+> 注意: クライアント描画ゲームの性質上、「画面データを読んで自動回答するボット」は完全には防げない。
+> 本実装が潰すのは(a)スコア捏造POSTと(b)瞬間周回。これが現実的なチートの大半。
+
+## デプロイ手順
+
+```bash
+cd teirei-kaigi/worker
+npm i -g wrangler        # 未導入なら
+wrangler login
+
+# 1) D1 を作成し、出力された database_id を wrangler.toml に貼る
+wrangler d1 create teirei-kaigi-ranking
+
+# 2) スキーマを適用(本番)
+wrangler d1 execute teirei-kaigi-ranking --remote --file=./schema.sql
+
+# 3) HMAC 署名鍵を登録(ランダムな長い文字列。例: openssl rand -hex 32)
+wrangler secret put HMAC_SECRET
+
+# 4) デプロイ
+wrangler deploy
+```
+
+デプロイ後に表示される URL(例 `https://teirei-kaigi-ranking.<account>.workers.dev`)を、
+ビルド時の環境変数 `VITE_RANKING_API` に設定する:
+
+```bash
+cd teirei-kaigi
+VITE_RANKING_API="https://teirei-kaigi-ranking.<account>.workers.dev" npm run build
+# dist/ の中身を apps/teirei-kaigi/ に差し替えてコミット
+```
+
+`VITE_RANKING_API` 未設定でビルドした場合、ランキングは無効化され、ゲームは
+従来どおり自己ベストのみで動作する(後方互換)。
+
+## ローカル確認
+
+```bash
+wrangler d1 execute teirei-kaigi-ranking --local --file=./schema.sql
+wrangler dev   # http://localhost:8787/session などを叩ける
+```

--- a/teirei-kaigi/worker/index.js
+++ b/teirei-kaigi/worker/index.js
@@ -1,0 +1,218 @@
+// ============================================================
+// 定例会議 エンドレスモード ランキング Worker (Cloudflare Workers + D1)
+//
+// ルート:
+//   GET  /session  … seed と署名付きセッションを発行する
+//   POST /submit   … 操作ログをサーバ側で再生・検証し、正式スコアを記録する
+//   GET  /top      … 上位ランキングを返す
+//
+// チート対策の要:
+//   - スコア値そのものは受け取らない。操作ログを seed 由来の列に突き合わせて再計算する。
+//   - seed は HMAC 署名付きで配布し、改ざんを検出する(鍵は Worker 内のみ)。
+//   - sid に UNIQUE 制約を張り、同一セッションの二重送信を遮断する。
+//   - 信頼できるサーバ時刻(発行 iat 〜 送信 now)と操作ログの所要時間を突き合わせ、
+//     瞬間周回(実時間を伴わない高スコア)を物理的に拒否する。
+// ============================================================
+
+import {
+  replay,
+  minPlayMs,
+  MAX_SESSION_MS,
+  MEETING_SECONDS,
+} from "../src/endlessCore.js";
+
+const TOP_LIMIT = 100;
+const NAME_MAX = 12;
+// 時間整合の許容ゆるみ(クロック差・初期化遅延を吸収)。
+const TIME_SLACK_MS = 5000;
+
+export default {
+  async fetch(request, env) {
+    const url = new URL(request.url);
+    const origin = env.ALLOW_ORIGIN || "*";
+
+    if (request.method === "OPTIONS") {
+      return new Response(null, { status: 204, headers: cors(origin) });
+    }
+
+    try {
+      if (url.pathname === "/session" && request.method === "GET") {
+        return await handleSession(env, origin);
+      }
+      if (url.pathname === "/submit" && request.method === "POST") {
+        return await handleSubmit(request, env, origin);
+      }
+      if (url.pathname === "/top" && request.method === "GET") {
+        return await handleTop(env, origin);
+      }
+      return json({ error: "not_found" }, 404, origin);
+    } catch (err) {
+      return json({ error: "internal", detail: String(err && err.message) }, 500, origin);
+    }
+  },
+};
+
+// ---- GET /session ----
+async function handleSession(env, origin) {
+  const seed = crypto.getRandomValues(new Uint32Array(1))[0] >>> 0;
+  const sid = hex(crypto.getRandomValues(new Uint8Array(16)));
+  const iat = Date.now();
+  const sig = await sign(env, `${seed}.${sid}.${iat}`);
+  return json({ seed, sid, iat, sig }, 200, origin);
+}
+
+// ---- POST /submit ----
+async function handleSubmit(request, env, origin) {
+  let body;
+  try {
+    body = await request.json();
+  } catch {
+    return json({ error: "bad_json" }, 400, origin);
+  }
+
+  const { seed, sid, iat, sig, name, inputs } = body || {};
+  if (
+    !Number.isFinite(seed) ||
+    typeof sid !== "string" ||
+    !Number.isFinite(iat) ||
+    typeof sig !== "string" ||
+    !Array.isArray(inputs)
+  ) {
+    return json({ error: "bad_request" }, 400, origin);
+  }
+
+  // 1) 署名検証(seed/sid/iat が当方発行のまま改ざんされていないこと)
+  const expected = await sign(env, `${seed >>> 0}.${sid}.${iat}`);
+  if (!timingSafeEqual(expected, sig)) {
+    return json({ error: "bad_sig" }, 401, origin);
+  }
+
+  // 2) セッションの鮮度(古すぎ・未来は拒否)
+  const now = Date.now();
+  const age = now - iat;
+  if (age < -TIME_SLACK_MS || age > MAX_SESSION_MS) {
+    return json({ error: "stale_session" }, 401, origin);
+  }
+
+  // 3) 操作ログを seed 列で再生し、正式 streak を再計算
+  const result = replay(seed >>> 0, inputs);
+  if (!result.ok) {
+    return json({ error: "invalid_play", reason: result.reason }, 422, origin);
+  }
+
+  // 4) 時間整合: 信頼できる経過時間(now - iat)と操作ログの所要時間を突き合わせる
+  const minTotal = minPlayMs(inputs);
+  if (age + TIME_SLACK_MS < minTotal) {
+    // 実時間が足りない = 瞬間周回の捏造
+    return json({ error: "too_fast" }, 422, origin);
+  }
+  let claimed = 0;
+  for (const inp of inputs) claimed += Number(inp.elapsedMs) || 0;
+  if (claimed > age + TIME_SLACK_MS + MEETING_SECONDS * 1000) {
+    // 申告した所要時間の合計が、実経過時間を超えている = 不整合
+    return json({ error: "time_mismatch" }, 422, origin);
+  }
+
+  const streak = result.streak;
+  const cleanName = sanitizeName(name);
+
+  // 5) 記録(sid の UNIQUE 制約で二重送信を遮断)
+  try {
+    await env.DB.prepare(
+      "INSERT INTO scores (sid, name, streak, created_at) VALUES (?, ?, ?, ?)"
+    )
+      .bind(sid, cleanName, streak, now)
+      .run();
+  } catch (err) {
+    // UNIQUE 制約違反 = 同一セッションの再送信
+    if (String(err && err.message).includes("UNIQUE")) {
+      return json({ error: "already_submitted" }, 409, origin);
+    }
+    throw err;
+  }
+
+  // 6) 順位と上位を返す
+  const rankRow = await env.DB.prepare(
+    "SELECT COUNT(*) AS c FROM scores WHERE streak > ?"
+  )
+    .bind(streak)
+    .first();
+  const rank = (rankRow ? rankRow.c : 0) + 1;
+  const top = await fetchTop(env);
+
+  return json({ ok: true, streak, rank, top }, 200, origin);
+}
+
+// ---- GET /top ----
+async function handleTop(env, origin) {
+  const top = await fetchTop(env);
+  return json({ top }, 200, origin, { "Cache-Control": "public, max-age=30" });
+}
+
+async function fetchTop(env) {
+  const rows = await env.DB.prepare(
+    "SELECT name, streak FROM scores ORDER BY streak DESC, created_at ASC LIMIT ?"
+  )
+    .bind(TOP_LIMIT)
+    .all();
+  return (rows.results || []).map((r) => ({ name: r.name, streak: r.streak }));
+}
+
+// ---- helpers ----
+function sanitizeName(name) {
+  if (typeof name !== "string") return "名無し";
+  // 制御文字を除去し、前後空白を落とし、長さを制限する
+  const clean = name
+    .replace(/[\u0000-\u001f\u007f]/g, "")
+    .trim()
+    .slice(0, NAME_MAX);
+  return clean.length > 0 ? clean : "名無し";
+}
+
+async function sign(env, message) {
+  const secret = env.HMAC_SECRET;
+  const key = await crypto.subtle.importKey(
+    "raw",
+    new TextEncoder().encode(secret),
+    { name: "HMAC", hash: "SHA-256" },
+    false,
+    ["sign"]
+  );
+  const mac = await crypto.subtle.sign("HMAC", key, new TextEncoder().encode(message));
+  return hex(new Uint8Array(mac));
+}
+
+function timingSafeEqual(a, b) {
+  if (typeof a !== "string" || typeof b !== "string" || a.length !== b.length) {
+    return false;
+  }
+  let diff = 0;
+  for (let i = 0; i < a.length; i++) diff |= a.charCodeAt(i) ^ b.charCodeAt(i);
+  return diff === 0;
+}
+
+function hex(bytes) {
+  let s = "";
+  for (const b of bytes) s += b.toString(16).padStart(2, "0");
+  return s;
+}
+
+function cors(origin) {
+  return {
+    "Access-Control-Allow-Origin": origin,
+    "Access-Control-Allow-Methods": "GET, POST, OPTIONS",
+    "Access-Control-Allow-Headers": "Content-Type",
+    "Access-Control-Max-Age": "86400",
+  };
+}
+
+function json(obj, status, origin, extra) {
+  return new Response(JSON.stringify(obj), {
+    status,
+    headers: {
+      "Content-Type": "application/json; charset=utf-8",
+      ...cors(origin),
+      ...(extra || {}),
+    },
+  });
+}

--- a/teirei-kaigi/worker/schema.sql
+++ b/teirei-kaigi/worker/schema.sql
@@ -1,0 +1,11 @@
+-- 定例会議 エンドレスランキングのスキーマ。
+-- 1セッション = 1行。sid を主キーにすることで同一セッションの二重送信を遮断する。
+CREATE TABLE IF NOT EXISTS scores (
+  sid        TEXT PRIMARY KEY,
+  name       TEXT NOT NULL,
+  streak     INTEGER NOT NULL,
+  created_at INTEGER NOT NULL
+);
+
+-- 上位取得(streak 降順、同値は先着優先)を高速化する。
+CREATE INDEX IF NOT EXISTS idx_scores_streak ON scores (streak DESC, created_at ASC);

--- a/teirei-kaigi/worker/wrangler.toml
+++ b/teirei-kaigi/worker/wrangler.toml
@@ -1,0 +1,17 @@
+name = "teirei-kaigi-ranking"
+main = "index.js"
+compatibility_date = "2024-11-01"
+
+# D1 データベース。`wrangler d1 create teirei-kaigi-ranking` で作成し、
+# 出力された database_id を下に貼る。
+[[d1_databases]]
+binding = "DB"
+database_name = "teirei-kaigi-ranking"
+database_id = "REPLACE_WITH_YOUR_D1_DATABASE_ID"
+
+[vars]
+# 本番では GitHub Pages のオリジンに絞る。ローカル確認時は "*" でもよい。
+ALLOW_ORIGIN = "https://taross-f.github.io"
+
+# HMAC_SECRET は vars に書かず、必ずシークレットとして登録すること:
+#   wrangler secret put HMAC_SECRET


### PR DESCRIPTION
## 概要

エンドレスモードの連続正解数(`streak`)を **Cloudflare Worker + D1** でオンラインランキング化します。
**スコア値そのものは送らず**、各ラウンドの操作ログ(`leave`/`stay` と所要時間)を送り、サーバが
seed 由来の決定論列に突き合わせて streak を再計算する設計で、チートを防ぎます。

## チート対策の仕組み

1. `GET /session` で **HMAC 署名付きの seed** を配布(鍵は Worker のシークレットのみ)。判定乱数はこの seed の決定論PRNGから生成され、クライアントとサーバで一致。
2. クライアントは **スコアではなく操作ログ**を送信。
3. `POST /submit` で Worker が:
   - HMAC 署名検証 → **seed 改ざんを検出**
   - `sid` の UNIQUE 制約 → **二重送信を遮断**
   - `replay()` で操作ログを seed 列に突き合わせ **streak を再計算**(途中失敗・末尾以外の不正解・型/範囲を拒否)
   - 信頼できる経過時間(発行〜送信)と所要時間を突き合わせ **瞬間周回を拒否**(`stay`=完走は実時間約35秒必須)

> **限界**: クライアント描画ゲームの性質上、画面データを読む自作ボットは完全には防げません。本実装が潰すのは **スコア捏造POST** と **瞬間周回**(=現実的なチートの大半)です。

## 変更点

- **`src/endlessCore.js`**(新規): クライアントとWorkerで共有する決定論コア。`mulberry32` / `generateSequence` / `replay` / `minPlayMs` / `ANOMALY_IDS`。
- **`worker/`**(新規): `index.js`(`/session`・`/submit`・`/top`)、`schema.sql`、`wrangler.toml`、`README.md`(デプロイ手順)。
- **`src/TeireiKaigi.jsx`**: エンドレスを seed 決定論出題に変更、操作ログ記録、終了画面に名前入力・自分の順位・上位10件を表示。`ranking_submit` GAイベント追加。
- **`CLAUDE.md`**: 設計とアナリティクスの追記。

## 後方互換

`VITE_RANKING_API` 未設定でビルドした場合はランキングを自動でオフライン化し、ゲームは従来どおり自己ベストのみで動作します。通常モード(月〜金)は無改修です。

## 検証

- `npm run build` 成功。
- 決定論コアの突き合わせ: 正直なプレイで client 列と server `replay` の streak が一致(複数seed・失敗位置で確認)。
- Worker e2e(D1スタブ＋実Web Crypto): honest=200 / 二重送信=409 / seed改ざん=401 / 瞬間送信=422(`too_fast`)を確認。

## マージ後にやること(Cloudflare 側・コマンドのみ)

`worker/README.md` の手順どおり:
1. `wrangler d1 create teirei-kaigi-ranking` → `database_id` を `wrangler.toml` に記入
2. `wrangler d1 execute ... --remote --file=./schema.sql`
3. `wrangler secret put HMAC_SECRET`(`openssl rand -hex 32` 等)
4. `wrangler deploy`
5. 表示された URL で `VITE_RANKING_API=... npm run build` し直し、`apps/teirei-kaigi/` を差し替え

> ※ 本PRには `apps/teirei-kaigi/` のビルド成果物は含めていません。Worker の URL が確定してから再ビルド・差し替えが必要なためです。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_015Ntsg6Fa65VLhvBk9JXNvd)_