### PR TITLE
トップページのヒーロー文言をシンプルにする

### DIFF
--- a/_data/strings.yml
+++ b/_data/strings.yml
@@ -8,8 +8,7 @@ ja:
     apps: "Apps"
     tags: "Tags"
   hero:
-    eyebrow: "Tech Notes & Experiments"
-    title: "日々のメモ、コードと共に。"
+    title: "技術メモ"
     subtitle: "フロントエンド、インフラ、ツール開発まで。気になったことを記録した技術ブログです。"
     cta: "最新の投稿を読む"
   common:
@@ -446,8 +445,7 @@ en:
     apps: "Apps"
     tags: "Tags"
   hero:
-    eyebrow: "Tech Notes & Experiments"
-    title: "Notes from the daily code grind."
+    title: "Tech Notes"
     subtitle: "Frontend, infrastructure, and tools — a personal log of things worth remembering."
     cta: "Read the latest posts"
   common:

--- a/index.html
+++ b/index.html
@@ -4,8 +4,7 @@ layout: default
 
 {% if paginator.page == 1 or paginator.page == nil %}
 <section class="hero reveal" data-parallax="0.12">
-  <span class="hero__eyebrow" data-i18n="hero.eyebrow">Tech Notes &amp; Experiments</span>
-  <h1 class="hero__title" data-i18n="hero.title">日々のメモ、コードと共に。</h1>
+  <h1 class="hero__title" data-i18n="hero.title">技術メモ</h1>
   <p class="hero__subtitle" data-i18n="hero.subtitle">
     フロントエンド、インフラ、ツール開発まで。気になったことを記録した技術ブログです。
   </p>

--- a/style.scss
+++ b/style.scss
@@ -980,40 +980,8 @@ iframe {
   }
 }
 
-.hero__eyebrow {
-  display: inline-flex;
-  align-items: center;
-  gap: 8px;
-  padding: 6px 14px;
-  font-size: 12px;
-  font-weight: 600;
-  letter-spacing: 1.5px;
-  text-transform: uppercase;
-  color: #{$brand-indigo};
-  background: rgba(255, 255, 255, 0.7);
-  border: 1px solid rgba(99, 102, 241, 0.25);
-  border-radius: 999px;
-  backdrop-filter: blur(10px);
-  box-shadow: 0 4px 16px rgba(99, 102, 241, 0.12);
-
-  &::before {
-    content: "";
-    width: 8px;
-    height: 8px;
-    border-radius: 50%;
-    background: #{$brand-pink};
-    box-shadow: 0 0 0 4px rgba(236, 72, 153, 0.25);
-    animation: heroPulse 2s ease-in-out infinite;
-  }
-}
-
-@keyframes heroPulse {
-  0%, 100% { box-shadow: 0 0 0 4px rgba(236, 72, 153, 0.25); }
-  50% { box-shadow: 0 0 0 10px rgba(236, 72, 153, 0); }
-}
-
 .hero__title {
-  margin: 24px auto 18px;
+  margin: 0 auto 18px;
   max-width: 880px;
   font-size: clamp(36px, 6vw, 64px);
   font-weight: 800;


### PR DESCRIPTION
## 概要

トップページのキャッチコピー調の文言をシンプルにしました。ブログ本文は変更していません。

## 変更内容

- 見出し「日々のメモ、コードと共に。」→「技術メモ」（英語版 "Notes from the daily code grind." → "Tech Notes"）
- 見出し上の飾りバッジ「Tech Notes & Experiments」（eyebrow）を削除し、未使用になった CSS（`.hero__eyebrow` と `heroPulse` アニメーション）も削除
- 説明文（サブタイトル）と「最新の投稿を読む」ボタンは普通の説明文のためそのまま

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KJCtrDVbPG1iy6uAQViWts

---
_Generated by [Claude Code](https://claude.ai/code/session_01KJCtrDVbPG1iy6uAQViWts)_